### PR TITLE
Add X-Accel-Buffering header

### DIFF
--- a/dist/server-sent-events.js
+++ b/dist/server-sent-events.js
@@ -189,6 +189,7 @@ var SSEClient = /** @class */ (function() {
 			"Content-Type": "text/event-stream",
 			"Cache-Control": "no-cache",
 			'Connection': 'keep-alive',
+			'X-Accel-Buffering': 'no',
 		},headers));
 		// write the retry interval and event id immediately
 		this.write("","",eventID);

--- a/server-sent-events.ts
+++ b/server-sent-events.ts
@@ -190,6 +190,7 @@ export class SSEClient implements AnyClient<"stream"> {
             "Content-Type": "text/event-stream",
             "Cache-Control": "no-cache",
             'Connection': 'keep-alive',
+            'X-Accel-Buffering': 'no',
         }, headers));
 
         // write the retry interval and event id immediately


### PR DESCRIPTION
@Arlen22 When using nginx for reverse proxy, SSE does not work properly. 
See for details：https://serverfault.com/questions/801628/for-server-sent-events-sse-what-nginx-proxy-configuration-is-appropriate